### PR TITLE
fix: Remove invalid if condition from CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,7 +56,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Deploy to Render
-        if: ${{ secrets.RENDER_DEPLOY_HOOK != '' }}
         env:
           RENDER_DEPLOY_HOOK: ${{ secrets.RENDER_DEPLOY_HOOK }}
         run: |


### PR DESCRIPTION
This PR fixes the workflow syntax error in the CD pipeline.

**Changes:**
- Remove invalid `if` condition that was causing workflow file errors
- The bash script already handles missing secrets gracefully

**Testing:**
- CI will run on this PR
- CD will run after merge to validate Docker build and Render deployment

Related to CD pipeline improvements.