### PR TITLE
fix: Handle deactivated Render deploys and add issues:write permission

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   contents: write
   packages: write
+  issues: write
 
 jobs:
   # Determine which action to run
@@ -191,7 +192,19 @@ jobs:
               echo "🎯 Your service is now live on Render!"
               echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
               exit 0
-            elif [ "$STATUS" = "build_failed" ] || [ "$STATUS" = "update_failed" ] || [ "$STATUS" = "deactivated" ]; then
+            elif [ "$STATUS" = "deactivated" ]; then
+              echo "⚠️  Deployment $DEPLOY_ID was deactivated (superseded by a newer deploy)."
+              echo "🔍 Switching to latest deployment on the service..."
+              LATEST_RESPONSE=$(curl -s -H "Authorization: Bearer $RENDER_API_KEY" \
+                "https://api.render.com/v1/services/$RENDER_SERVICE_ID/deploys?limit=1")
+              DEPLOY_ID=$(echo "$LATEST_RESPONSE" | jq -r '.[0].deploy.id // empty')
+              STATUS=$(echo "$LATEST_RESPONSE" | jq -r '.[0].deploy.status // "unknown"')
+              echo "📦 New Deployment ID: $DEPLOY_ID | Status: $STATUS"
+              if [ "$STATUS" = "live" ]; then
+                echo "✅ Latest deployment is already LIVE!"
+                exit 0
+              fi
+            elif [ "$STATUS" = "build_failed" ] || [ "$STATUS" = "update_failed" ]; then
               echo ""
               echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
               echo "❌ Deployment failed with status: $STATUS"


### PR DESCRIPTION
## Summary
- When Render deactivates a deployment (superseded by a newer one), the CD was treating it as failure. Now it switches to polling the latest deployment instead
- Adds `issues: write` permission so the auto-rollback job can create GitHub issues on failure

## Root cause
The CD pipeline triggered a deploy hook, but Render's auto-redeploy (from env var change) kicked off a second deploy which superseded the first → CD saw `deactivated` → false failure.