### PR TITLE
feat: Add E2E regression suite to CD pipeline post-deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -360,6 +360,28 @@ jobs:
         env:
           BASE_URL: ${{ secrets.RENDER_APP_URL }}
 
+      - name: Run E2E regression suite
+        if: steps.deploy.outputs.deploy_id != ''
+        env:
+          RENDER_APP_URL: ${{ secrets.RENDER_APP_URL }}
+        run: |
+          echo "🧪 Running E2E regression suite against live environment..."
+          APP_URL="${RENDER_APP_URL:-https://worktime-leave-manager-wtlm.onrender.com}"
+          echo "🌐 Target: $APP_URL"
+          echo ""
+
+          npm install -g newman --silent
+
+          newman run test/e2e/regression-collection.json \
+            --env-var "baseUrl=$APP_URL" \
+            --reporters cli \
+            --bail
+
+          echo ""
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "✅ E2E regression suite passed"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
       - name: Store deployment info for rollback
         if: success()
         run: |

--- a/test/e2e/regression-collection.json
+++ b/test/e2e/regression-collection.json
@@ -1,0 +1,342 @@
+{
+  "info": {
+    "name": "WTLM E2E Regression Suite",
+    "description": "Full regression suite run post-deploy against live Render environment. Tests complete business flows with assertions and request chaining.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "baseUrl", "value": "https://worktime-leave-manager-wtlm.onrender.com" },
+    { "key": "leaveId1", "value": "" },
+    { "key": "leaveId2", "value": "" }
+  ],
+  "item": [
+    {
+      "name": "1. Health Check",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": { "raw": "{{baseUrl}}/health", "host": ["{{baseUrl}}"], "path": ["health"] }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Health: status 200', () => pm.response.to.have.status(200));",
+              "pm.test('Health: body status is ok', () => {",
+              "  const body = pm.response.json();",
+              "  pm.expect(body.status).to.eql('ok');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "2. Create Leave Request #1 (to approve)",
+      "request": {
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"employeeId\": \"E2E-REGR-001\",\n  \"leaveType\": \"vacation\",\n  \"startDate\": \"2026-04-01T00:00:00.000Z\",\n  \"endDate\": \"2026-04-05T00:00:00.000Z\",\n  \"reason\": \"E2E regression test - to approve\"\n}"
+        },
+        "url": { "raw": "{{baseUrl}}/leave-requests", "host": ["{{baseUrl}}"], "path": ["leave-requests"] }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Create #1: status 201', () => pm.response.to.have.status(201));",
+              "pm.test('Create #1: has id', () => {",
+              "  const body = pm.response.json();",
+              "  pm.expect(body.id).to.be.a('string').and.not.empty;",
+              "  pm.collectionVariables.set('leaveId1', body.id);",
+              "});",
+              "pm.test('Create #1: status is pending', () => {",
+              "  pm.expect(pm.response.json().status).to.eql('pending');",
+              "});",
+              "pm.test('Create #1: employeeId matches', () => {",
+              "  pm.expect(pm.response.json().employeeId).to.eql('E2E-REGR-001');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "3. Create Leave Request #2 (to reject)",
+      "request": {
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"employeeId\": \"E2E-REGR-002\",\n  \"leaveType\": \"sick\",\n  \"startDate\": \"2026-04-10T00:00:00.000Z\",\n  \"endDate\": \"2026-04-12T00:00:00.000Z\",\n  \"reason\": \"E2E regression test - to reject\"\n}"
+        },
+        "url": { "raw": "{{baseUrl}}/leave-requests", "host": ["{{baseUrl}}"], "path": ["leave-requests"] }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Create #2: status 201', () => pm.response.to.have.status(201));",
+              "pm.test('Create #2: has id', () => {",
+              "  const body = pm.response.json();",
+              "  pm.expect(body.id).to.be.a('string').and.not.empty;",
+              "  pm.collectionVariables.set('leaveId2', body.id);",
+              "});",
+              "pm.test('Create #2: leaveType is sick', () => {",
+              "  pm.expect(pm.response.json().leaveType).to.eql('sick');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "4. Get All Leave Requests",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": { "raw": "{{baseUrl}}/leave-requests", "host": ["{{baseUrl}}"], "path": ["leave-requests"] }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('List: status 200', () => pm.response.to.have.status(200));",
+              "pm.test('List: returns array', () => {",
+              "  pm.expect(pm.response.json()).to.be.an('array');",
+              "});",
+              "pm.test('List: contains created requests', () => {",
+              "  const ids = pm.response.json().map(r => r.id);",
+              "  pm.expect(ids).to.include(pm.collectionVariables.get('leaveId1'));",
+              "  pm.expect(ids).to.include(pm.collectionVariables.get('leaveId2'));",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "5. Get Leave Requests by Employee",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/leave-requests?employeeId=E2E-REGR-001",
+          "host": ["{{baseUrl}}"],
+          "path": ["leave-requests"],
+          "query": [{ "key": "employeeId", "value": "E2E-REGR-001" }]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Filter by employee: status 200', () => pm.response.to.have.status(200));",
+              "pm.test('Filter by employee: returns array', () => {",
+              "  pm.expect(pm.response.json()).to.be.an('array');",
+              "});",
+              "pm.test('Filter by employee: all records belong to E2E-REGR-001', () => {",
+              "  pm.response.json().forEach(r => {",
+              "    pm.expect(r.employeeId).to.eql('E2E-REGR-001');",
+              "  });",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "6. Get Leave Request by ID",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/leave-requests/{{leaveId1}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["leave-requests", "{{leaveId1}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Get by ID: status 200', () => pm.response.to.have.status(200));",
+              "pm.test('Get by ID: id matches', () => {",
+              "  pm.expect(pm.response.json().id).to.eql(pm.collectionVariables.get('leaveId1'));",
+              "});",
+              "pm.test('Get by ID: has required fields', () => {",
+              "  const body = pm.response.json();",
+              "  pm.expect(body).to.have.all.keys('id', 'employeeId', 'leaveType', 'startDate', 'endDate', 'reason', 'status');",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "7. Get Leave Statistics",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": { "raw": "{{baseUrl}}/leave-requests/statistics", "host": ["{{baseUrl}}"], "path": ["leave-requests", "statistics"] }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Statistics: status 200', () => pm.response.to.have.status(200));",
+              "pm.test('Statistics: has total field', () => {",
+              "  pm.expect(pm.response.json().total).to.be.a('number');",
+              "});",
+              "pm.test('Statistics: total >= 2', () => {",
+              "  pm.expect(pm.response.json().total).to.be.at.least(2);",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "8. Get Leave Statistics by Employee",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/leave-requests/statistics?employeeId=E2E-REGR-001",
+          "host": ["{{baseUrl}}"],
+          "path": ["leave-requests", "statistics"],
+          "query": [{ "key": "employeeId", "value": "E2E-REGR-001" }]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Statistics by employee: status 200', () => pm.response.to.have.status(200));",
+              "pm.test('Statistics by employee: has total', () => {",
+              "  pm.expect(pm.response.json().total).to.be.a('number');",
+              "});",
+              "pm.test('Statistics by employee: total >= 1', () => {",
+              "  pm.expect(pm.response.json().total).to.be.at.least(1);",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "9. Approve Leave Request #1",
+      "request": {
+        "method": "PATCH",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/leave-requests/{{leaveId1}}/approve",
+          "host": ["{{baseUrl}}"],
+          "path": ["leave-requests", "{{leaveId1}}", "approve"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Approve: status 200', () => pm.response.to.have.status(200));",
+              "pm.test('Approve: status is approved', () => {",
+              "  pm.expect(pm.response.json().status).to.eql('approved');",
+              "});",
+              "pm.test('Approve: id matches', () => {",
+              "  pm.expect(pm.response.json().id).to.eql(pm.collectionVariables.get('leaveId1'));",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "10. Reject Leave Request #2",
+      "request": {
+        "method": "PATCH",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/leave-requests/{{leaveId2}}/reject",
+          "host": ["{{baseUrl}}"],
+          "path": ["leave-requests", "{{leaveId2}}", "reject"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Reject: status 200', () => pm.response.to.have.status(200));",
+              "pm.test('Reject: status is rejected', () => {",
+              "  pm.expect(pm.response.json().status).to.eql('rejected');",
+              "});",
+              "pm.test('Reject: id matches', () => {",
+              "  pm.expect(pm.response.json().id).to.eql(pm.collectionVariables.get('leaveId2'));",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "11. Cleanup - Delete Leave Request #1",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/leave-requests/{{leaveId1}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["leave-requests", "{{leaveId1}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Delete #1: status 200 or 204', () => {",
+              "  pm.expect(pm.response.code).to.be.oneOf([200, 204]);",
+              "});"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "12. Cleanup - Delete Leave Request #2",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/leave-requests/{{leaveId2}}",
+          "host": ["{{baseUrl}}"],
+          "path": ["leave-requests", "{{leaveId2}}"]
+        }
+      },
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test('Delete #2: status 200 or 204', () => {",
+              "  pm.expect(pm.response.code).to.be.oneOf([200, 204]);",
+              "});"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `test/e2e/regression-collection.json`: 12-step Newman regression suite with full assertions and request chaining
- Runs in CD pipeline **after K6 load tests**, against the live Render URL
- Uses `--bail` so any assertion failure stops the suite and triggers auto-rollback

## E2E flow
| Step | Endpoint | Asserts |
|------|----------|---------|
| 1 | GET /health | 200, status=ok |
| 2 | POST /leave-requests | 201, captures leaveId1 |
| 3 | POST /leave-requests | 201, captures leaveId2 |
| 4 | GET /leave-requests | 200, array contains both |
| 5 | GET /leave-requests?employeeId=... | 200, filtered correctly |
| 6 | GET /leave-requests/:leaveId1 | 200, correct fields |
| 7 | GET /leave-requests/statistics | 200, total >= 2 |
| 8 | GET /leave-requests/statistics?employeeId=... | 200, total >= 1 |
| 9 | PATCH /:leaveId1/approve | 200, status=approved |
| 10 | PATCH /:leaveId2/reject | 200, status=rejected |
| 11 | DELETE /:leaveId1 | 200 or 204 |
| 12 | DELETE /:leaveId2 | 200 or 204 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)