### PR TITLE
fix: Use include.all.keys in E2E assertion

### DIFF
--- a/test/e2e/regression-collection.json
+++ b/test/e2e/regression-collection.json
@@ -174,7 +174,7 @@
               "});",
               "pm.test('Get by ID: has required fields', () => {",
               "  const body = pm.response.json();",
-              "  pm.expect(body).to.have.all.keys('id', 'employeeId', 'leaveType', 'startDate', 'endDate', 'reason', 'status');",
+              "  pm.expect(body).to.include.all.keys('id', 'employeeId', 'leaveType', 'startDate', 'endDate', 'reason', 'status');",
               "});"
             ]
           }


### PR DESCRIPTION
have.all.keys requires exact match → fails because response has createdAt/updatedAt too. Fixed to include.all.keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)